### PR TITLE
Reduce CPU request

### DIFF
--- a/helm/sitesearch-chart/templates/deployment.yaml
+++ b/helm/sitesearch-chart/templates/deployment.yaml
@@ -23,10 +23,10 @@ spec:
               name: http
           resources:
             requests:
-              cpu: 0.5
+              cpu: 250m
               memory: 700M
             limits:
-              cpu: 1.0
+              cpu: 500m
               memory: 700M
 
       imagePullSecrets:


### PR DESCRIPTION
Elasticsearch is mostly idle. It should not reserve half a core for that.