### PR TITLE
Reduce CPU request and limit

### DIFF
--- a/helm/sitesearch-chart/templates/deployment.yaml
+++ b/helm/sitesearch-chart/templates/deployment.yaml
@@ -23,10 +23,10 @@ spec:
               name: http
           resources:
             requests:
-              cpu: 0.5
+              cpu: 200m
               memory: 700M
             limits:
-              cpu: 1.0
+              cpu: 500m
               memory: 700M
 
       imagePullSecrets:


### PR DESCRIPTION
In order to be able to place all our frontend cluster workloads on a small cluster, this is the attempt to shave off a bit of overhead.

Part of https://github.com/giantswarm/giantswarm/issues/3686