### PR TITLE
Update architect-orb to 2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.18.1
+  architect: giantswarm/architect@2.1.0
 
 jobs:
   build:


### PR DESCRIPTION
Update architect-orb to 2.1.0 which will use giantswarm.github.io as catalog base url. The old behaviour was to use giantswarm.github.com which will be deprecated in april by GitHub. Towards giantswarm/giantswarm#15898