### PR TITLE
Change storage class to gp3

### DIFF
--- a/helm/sitesearch-app/templates/persistent-volume-claim.yaml
+++ b/helm/sitesearch-app/templates/persistent-volume-claim.yaml
@@ -11,4 +11,4 @@ spec:
   resources:
     requests:
       storage: 3Gi
-  storageClassName: managed-standard
+  storageClassName: gp3


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29470

`managed-standard` is not available on gazelle/operations, but `gp3` is.