### PR TITLE
Set deployment strategy to Recreate

### DIFF
--- a/helm/sitesearch-app/templates/deployment.yaml
+++ b/helm/sitesearch-app/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.name }}
+  strategy:
+    # There must be only one pod running at a time, due to volume write lock restrictions.
+    type: Recreate
   template:
     metadata:
       name: {{ .Values.name }}


### PR DESCRIPTION
With the default strategy, an upgrade to a new release fails, as this results in two pods trying to obtain the volume write lock at the same time.

With the `Recreate` strategy, the existing pod will be taken down before the new pod gets launched.

```
[2024-03-13T14:00:53,126][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [sitesearch1] uncaught exception in thread [main]
org.elasticsearch.bootstrap.StartupException: java.lang.IllegalStateException: failed to obtain node locks, tried [[/usr/share/elasticsearch/data]] with lock id [0]; maybe these locations are not writable or multiple nodes were started w
ithout increasing [node.max_local_storage_nodes] (was [1])?
    at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:163) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:150) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124) ~[elasticsearch-cli-6.8.13.jar:6.8.13]
    at org.elasticsearch.cli.Command.main(Command.java:90) ~[elasticsearch-cli-6.8.13.jar:6.8.13]
    at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:116) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:93) ~[elasticsearch-6.8.13.jar:6.8.13]
Caused by: java.lang.IllegalStateException: failed to obtain node locks, tried [[/usr/share/elasticsearch/data]] with lock id [0]; maybe these locations are not writable or multiple nodes were started without increasing [node.max_local_s
torage_nodes] (was [1])?
    at org.elasticsearch.env.NodeEnvironment.<init>(NodeEnvironment.java:300) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.node.Node.<init>(Node.java:296) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.node.Node.<init>(Node.java:266) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:212) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:212) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:333) ~[elasticsearch-6.8.13.jar:6.8.13]
    at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159) ~[elasticsearch-6.8.13.jar:6.8.13]
    ... 6 more
```