### PR TITLE
fix: lower OpenSearch MaxRAMPercentage to 50 to avoid OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Lower OpenSearch `MaxRAMPercentage` from 80 to 50 so the JVM heap leaves enough headroom for off-heap/Lucene memory within the container limit (was OOMKilled at 80%).
 - Prepare chart for use with Flux OCIRepository + HelmRelease.
 - Sanitize `.Chart.Version` in labels with `commit` and `branch` helpers.
 - Use common labels and selectors consistently on all resources.

--- a/helm/sitesearch/templates/deployment.yaml
+++ b/helm/sitesearch/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
             - name: bootstrap.memory_lock
               value: "false"
             - name: OPENSEARCH_JAVA_OPTS
-              value: "-XX:+UseContainerSupport -XX:InitialRAMPercentage=50.0 -XX:MinRAMPercentage=50.0 -XX:MaxRAMPercentage=80.0"
+              value: "-XX:+UseContainerSupport -XX:InitialRAMPercentage=50.0 -XX:MinRAMPercentage=50.0 -XX:MaxRAMPercentage=50.0"
             - name: OPENSEARCH_HOME
               value: /usr/share/opensearch
             {{- if .Values.opensearch.securityDisabled }}


### PR DESCRIPTION
## What

Lower `-XX:MaxRAMPercentage` from `80.0` to `50.0` in the OpenSearch `OPENSEARCH_JAVA_OPTS`.

## Why

With heap sized at 80% of the container memory limit, OpenSearch had too little headroom for off-heap/Lucene memory + JVM overhead and was **OOMKilled** (exit 137) in a crashloop after the App CR → HelmRelease migration — especially under indexing load. 50% heap is the OpenSearch best-practice split and leaves room for off-heap.

Paired with a memory-limit increase (1600M → 3072M) in the workload-clusters-fleet user-values ConfigMap.