### PR TITLE
fix: raise default ephemeral-storage for OpenSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Raise default `ephemeral-storage` (requests 100Mi→512Mi, limits 500Mi→2Gi). OpenSearch's logs and plugins dirs are `emptyDir` (ephemeral), and the bundled plugins + logs exceed 500Mi, causing the pod to be evicted with `ephemeral local storage usage exceeds the total limit`.
 - Lower OpenSearch `MaxRAMPercentage` from 80 to 50 so the JVM heap leaves enough headroom for off-heap/Lucene memory within the container limit (was OOMKilled at 80%).
 - Prepare chart for use with Flux OCIRepository + HelmRelease.
 - Sanitize `.Chart.Version` in labels with `commit` and `branch` helpers.

--- a/helm/sitesearch/README.md
+++ b/helm/sitesearch/README.md
@@ -19,7 +19,7 @@ OpenSearch-based search engine for the Giant Swarm documentation at https://docs
 | opensearch.forceCleanStart | bool | `false` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"650Mi"` |  |
-| resources.requests.ephemeralStorage | string | `"100Mi"` |  |
+| resources.requests.ephemeralStorage | string | `"512Mi"` |  |
 | resources.limits.cpu | string | `"500m"` |  |
 | resources.limits.memory | string | `"800Mi"` |  |
-| resources.limits.ephemeralStorage | string | `"500Mi"` |  |
+| resources.limits.ephemeralStorage | string | `"2Gi"` |  |

--- a/helm/sitesearch/values.yaml
+++ b/helm/sitesearch/values.yaml
@@ -20,8 +20,8 @@ resources:
   requests:
     cpu: 100m
     memory: 650Mi
-    ephemeralStorage: 100Mi
+    ephemeralStorage: 512Mi
   limits:
     cpu: 500m
     memory: 800Mi
-    ephemeralStorage: 500Mi
+    ephemeralStorage: 2Gi


### PR DESCRIPTION
## What

Raise the chart's default `ephemeral-storage`: requests `100Mi → 512Mi`, limits `500Mi → 2Gi`.

## Why

OpenSearch keeps its **data** on the PVC, but its **logs** and **plugins** dirs are `emptyDir` (ephemeral). OpenSearch 3.4.0's bundled plugins (KNN, SQL, security-analytics, …) plus logs exceed the previous `500Mi` limit, so the pod is **evicted** shortly after startup:

```
Pod ephemeral local storage usage exceeds the total limit of containers 500Mi.
```

We already worked around this per-environment in workload-clusters-fleet (operations user-values), but the chart default is too low for any OpenSearch deployment — this fixes it at the source.

## Verification

`helm template` renders the new limits; `helm lint` + schema pass.